### PR TITLE
Specify filename with CLI options

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -9,11 +9,25 @@
 const editor = require('editor');
 const changes = require('..');
 
+const argv = require('minimist')(process.argv.slice(2), {
+  alias: {
+    file: 'f'
+  }
+});
+
+let file = argv.file;
+
+if (file) {
+  changes.setFile(file);
+} else {
+  file = changes.getFile();
+}
+
 // Write the commit history to the changes file
 const previous = changes.write();
 
 // Let the user edit the changes
-editor('CHANGES.md', (code) => {
+editor(file, (code) => {
   if (code === 0) {
     // Add the changes file to git
     changes.add(previous);

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -11,9 +11,23 @@ const changes = require('..');
 
 const argv = require('minimist')(process.argv.slice(2), {
   alias: {
-    file: 'f'
+    file: 'f',
+    help: 'h'
   }
 });
+/* eslint-disable max-len */
+const HELP_TEXT = `usage: changes [--file] [--help]
+
+Options are ...
+  -f, --file [FILENAME] Specify the name of the changelog file. Defaults to CHANGES.md.
+  -h, --help            Display this help message.
+`;
+/* eslint-enable */
+
+if (argv.h || argv.help) {
+  console.log(HELP_TEXT);
+  process.exit();
+}
 
 let file = argv.file;
 

--- a/lib/changes.js
+++ b/lib/changes.js
@@ -8,8 +8,8 @@
 const fs = require('fs');
 const $ = require('child_process');
 
-const CHANGES_FILE = 'CHANGES.md';
 const CHANGES_HEADING = '# Changes';
+let CHANGES_FILE = 'CHANGES.md';
 
 function exists(changes, version) {
   const escaped_version = version.replace(/([\.\-])/g, '\\$1');
@@ -100,4 +100,14 @@ exports.add = function (previous) {
   } else {
     exports.abort(previous);
   }
+};
+
+// Get file to write changelog
+exports.getFile = function () {
+  return CHANGES_FILE;
+};
+
+// Set file to write changelog
+exports.setFile = function (file) {
+  CHANGES_FILE = file;
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     }
   },
   "dependencies": {
-    "editor": "^1.0.0"
+    "editor": "^1.0.0",
+    "minimist": "^1.2.0"
   },
   "devDependencies": {
     "@studio/eslint-config": "^1.0.0",

--- a/test/changes-test.js
+++ b/test/changes-test.js
@@ -39,6 +39,25 @@ describe('changes', () => {
     $.execSync.returns(log);
   }
 
+  it('defaults changes file to CHANGES.md', () => {
+    assert.equal(changes.getFile(), 'CHANGES.md');
+  });
+
+  it('can set changes file to custom name', () => {
+    changes.setFile('foo.txt');
+
+    assert.equal(changes.getFile(), 'foo.txt');
+
+    missingChanges();
+    setLog('foo');
+
+    changes.write();
+
+    sinon.assert.calledWith(fs.writeFileSync, 'foo.txt');
+
+    changes.setFile('CHANGES.md'); // reset state
+  });
+
   it('generates new changes file', () => {
     missingChanges();
     setLog('» Inception (That Dude)\n\n\n\n');


### PR DESCRIPTION
Set up changes to be an instance of a Changes function. This is _technically_ a breaking change if this module is being used programatically. If you'd prefer not to do a major version bump, I can rewrite it to not be a breaking change, but the code is messier (as you either need to pass in the file name to both methods, or provide some new method to set a variable for the file name.

Also added a help message.