### PR TITLE
Quote commit body

### DIFF
--- a/lib/changes.js
+++ b/lib/changes.js
@@ -57,7 +57,7 @@ exports.write = function () {
 
   // Remove blanks (if no body) and indent body
   changes = changes.replace(/\n{3,}/g, '\n')
-    .replace(/^([^\»\s])/gm, '    $1')
+    .replace(/^([^\»\s])/gm, '    > $1')
     .replace(/^»/gm, '-')
     .replace(/\n/gm, newline);
 

--- a/test/changes-test.js
+++ b/test/changes-test.js
@@ -116,9 +116,9 @@ describe('changes', () => {
     sinon.assert.calledOnce(fs.writeFileSync);
     sinon.assert.calledWith(fs.writeFileSync, 'CHANGES.md',
       '# Changes\n\n## 1.0.0\n\n'
-      + '- Inception\n\n    Foo Bar Doo\n\n'
+      + '- Inception\n\n    > Foo Bar Doo\n\n'
       + '- Other (Dude)\n'
-      + '- Third (Person)\n\n    Does\n    stuff\n\n');
+      + '- Third (Person)\n\n    > Does\n    > stuff\n\n');
   });
 
   it('properly indents lists', () => {
@@ -130,7 +130,7 @@ describe('changes', () => {
     sinon.assert.calledOnce(fs.writeFileSync);
     sinon.assert.calledWith(fs.writeFileSync, 'CHANGES.md',
       '# Changes\n\n## 1.0.0\n\n'
-      + '- Inception\n\n    - Foo\n    - Bar\n    - Doo\n\n');
+      + '- Inception\n\n    > - Foo\n    > - Bar\n    > - Doo\n\n');
   });
 
   it('fails if changes file has not the right format', () => {
@@ -187,7 +187,7 @@ describe('changes', () => {
 
     sinon.assert.calledOnce(fs.writeFileSync);
     sinon.assert.calledWith(fs.writeFileSync, 'CHANGES.md', '# Changes\r\n\r\n'
-      + '## 1.0.0\r\n\r\n- JavaScript\r\n\r\n    What else?\r\n\r\n'
+      + '## 1.0.0\r\n\r\n- JavaScript\r\n\r\n    > What else?\r\n\r\n'
       + '## 0.0.1\r\n\r\n- Inception\r\n');
     sinon.assert.calledOnce($.execSync);
     sinon.assert.calledWithMatch($.execSync, 'git log v0.0.1..HEAD');


### PR DESCRIPTION
Render commit bodies as markdown quotes to better group long commit messages.

Here is an example:

# Changes

## 1.2.0

- 🎉 There has been that awesome change

    > It needs a somewhat longish explanation which the author
    > has but in the commit body.

- 🐛 Another change was made

    > This time, there is even a list of things to consider in the
    > body of the commit:
    >
    > - Namely this
    > - And also that
