### PR TITLE
feat: custom git tag format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ indentation style will be preserved.
 - `--file`, `-f`: Specify the name of the changelog file. Defaults to
   `CHANGES.md`.
 - `--init`: Add version lifecycle scripts to `package.json`.
+- `--tag`: Use a custom git tag, supports simple replacement of `package.json`
+  fields. Defaults to `v${version}`.
 
 Configure your preferred editor with the `$EDITOR` environment variable.
 

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -24,7 +24,7 @@ if (argv.help) {
 Options:
       --init            Add version lifecycle scripts to package.json.
   -f, --file [FILENAME] Specify the name of the changelog file. Defaults to CHANGES.md.
-  -t, --tag [FORMAT]    Specify a custom git tag format to use. Defaults to "v<version>".
+  -t, --tag [FORMAT]    Specify a custom git tag format to use. Defaults to "v\${version}".
   -h, --help            Display this help message.
 `);
   /* eslint-enable */

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -47,7 +47,7 @@ if (file) {
   file = changes.getFile();
 }
 
-let tag = argv.tag;
+const tag = argv.tag;
 
 if (tag) {
   changes.setTag(tag);

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -12,6 +12,7 @@ const changes = require('..');
 const argv = require('minimist')(process.argv.slice(2), {
   alias: {
     file: 'f',
+    tag: 't',
     help: 'h'
   }
 });
@@ -23,6 +24,7 @@ if (argv.help) {
 Options:
       --init            Add version lifecycle scripts to package.json.
   -f, --file [FILENAME] Specify the name of the changelog file. Defaults to CHANGES.md.
+  -t, --tag [FORMAT]    Specify a custom git tag format to use. Defaults to "v<version>".
   -h, --help            Display this help message.
 `);
   /* eslint-enable */
@@ -43,6 +45,12 @@ if (file) {
   changes.setFile(file);
 } else {
   file = changes.getFile();
+}
+
+let tag = argv.tag;
+
+if (tag) {
+  changes.setTag(tag);
 }
 
 // Write the commit history to the changes file

--- a/lib/changes.js
+++ b/lib/changes.js
@@ -10,6 +10,7 @@ const $ = require('child_process');
 
 const CHANGES_HEADING = '# Changes';
 let CHANGES_FILE = 'CHANGES.md';
+let TAG_FORMAT = 'v${version}';
 
 function exists(changes, version) {
   const escaped_version = version.replace(/([\.\-])/g, '\\$1');
@@ -17,10 +18,17 @@ function exists(changes, version) {
   return regexp.test(changes);
 }
 
+function buildTag(version, pkg) {
+  return TAG_FORMAT.replace(/\$\{([^}]+)\}/g, (match, key) =>
+    key === 'version' ? version : pkg[key]
+  );
+}
+
 // Write the commit history to the changes file
 exports.write = function () {
   const package_json = fs.readFileSync('package.json', 'utf8');
-  const { version, author } = JSON.parse(package_json);
+  const pkg = JSON.parse(package_json);
+  const { version, author } = pkg;
 
   // Get previous file content
   let previous;
@@ -43,7 +51,7 @@ exports.write = function () {
 
   // Generate changes for this release
   const version_match = previous.match(/^## ([0-9a-z\.\-]+)$/m);
-  const log_range = version_match ? `v${version_match[1]}..HEAD` : '';
+  const log_range = version_match ? `${buildTag(version_match[1], pkg)}..HEAD` : '';
   const flags = '--format="» %s (%an)%n%n%b" --no-merges';
   let changes;
   try {
@@ -115,3 +123,8 @@ exports.getFile = function () {
 exports.setFile = function (file) {
   CHANGES_FILE = file;
 };
+
+// Set tag format for git lookups
+exports.setTag = function (tag) {
+  TAG_FORMAT = tag;
+}

--- a/test/changes-test.js
+++ b/test/changes-test.js
@@ -18,6 +18,7 @@ describe('changes', () => {
     sandbox.stub(process, 'exit');
     sandbox.stub(console, 'error');
     fs.readFileSync.withArgs('package.json').returns(JSON.stringify({
+      name: '@studio/changes',
       version: '1.0.0',
       author: 'Studio <support@javascript.studio>'
     }));
@@ -204,6 +205,25 @@ describe('changes', () => {
       'Version 1.0.0 is already in CHANGES.md\n');
     sinon.assert.calledOnce(process.exit);
     sinon.assert.calledWith(process.exit, 1);
+  });
+
+  it('should support custom tag formats when updating a file', () => {
+    const initial = '# Changes\n\n## 0.1.0\n\nSome foo.\n';
+    setChanges(initial);
+    setLog('» Inception (Studio)\n\n\n');
+
+    changes.setTag('${name}@${version}');
+
+    const previous = changes.write();
+    
+    sinon.assert.calledOnce(fs.writeFileSync);
+    sinon.assert.calledWith(fs.writeFileSync, 'CHANGES.md',
+      '# Changes\n\n## 1.0.0\n\n- Inception\n\n## 0.1.0\n\nSome foo.\n');
+    sinon.assert.calledOnce($.execSync);
+    sinon.assert.calledWithMatch($.execSync, 'git log @studio/changes@0.1.0..HEAD');
+    assert.equal(previous, initial);
+
+    changes.setTag('v${version}'); // reset state
   });
 
 });


### PR DESCRIPTION
Supports the parsed version from `CHANGES.md` as `${version}` along w/ any other string-compatible key in `package.json`.

Now it's possible to use this lib with lerna!

```bash
$ changes -t ${name}@${version}
```

Fixes #15 