### PR TITLE
Resolve "repository" field from package.json

### DIFF
--- a/lib/changes.js
+++ b/lib/changes.js
@@ -7,6 +7,7 @@
 
 const fs = require('fs');
 const $ = require('child_process');
+const hostedGitInfo = require('hosted-git-info');
 const changelog = require('./changelog');
 const github = require('./github');
 
@@ -87,9 +88,18 @@ exports.write = function (options, callback) {
   if (commits) {
     if (commits === true) {
       commits = DEFAULT_COMMIT_URL_FORMAT;
+      if (pkg.repository && pkg.repository.type === 'git') {
+        const info = hostedGitInfo.fromUrl(pkg.repository.url);
+        if (!info) {
+          console.error('Failed to parse "repository" from package.json\n');
+          process.exit(1);
+          return;
+        }
+        pkg.homepage = info.browse();
+      }
       if (!pkg.homepage) {
-        console.error('--commits option requires base URL or "homepage" in '
-          + 'package.json\n');
+        console.error('--commits option requires base URL, "repository" or '
+          + '"homepage" in package.json\n');
         process.exit(1);
         return;
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -756,6 +756,14 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "hosted-git-info": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.2.tgz",
+      "integrity": "sha512-ezZMWtHXm7Eb7Rq4Mwnx2vs79WUx2QmRg3+ZqeGroKzfDO+EprOcgRPYghsOP9JuYBfK18VojmRTGCg8Ma+ktw==",
+      "requires": {
+        "lru-cache": "^5.1.1"
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -1006,6 +1014,14 @@
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.1.0.tgz",
       "integrity": "sha512-BYxIEXiVq5lGIXeVHnsFzqa1TxN5acnKnPCdlZSpzm8viNEOhiigupA4vTQ9HEFQ6nLTQ9wQOgBknJgzUYQ9Aw==",
       "dev": true
+    },
+    "lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "requires": {
+        "yallist": "^3.0.2"
+      }
     },
     "map-age-cleaner": {
       "version": "0.1.3",
@@ -1776,6 +1792,11 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
+    },
+    "yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yargs": {
       "version": "13.2.2",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@studio/editor": "^1.1.1",
     "@studio/json-request": "^3.0.0",
     "detect-indent": "^5.0.0",
+    "hosted-git-info": "^3.0.2",
     "minimist": "^1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
With this change, `hosted-git-info` is used to parse the "repository" field in the `package.json` file to find the homepage for commit links.