### PR TITLE
Publish to npm with public access when package is scoped and public

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -16,6 +16,14 @@ function addScript(scripts, name, source) {
   return false;
 }
 
+function isScopedPublicPackage(pkg) {
+  return (
+    pkg.private === false &&
+    typeof pkg.name === 'string' &&
+    pkg.name.indexOf('@') === 0
+  );
+}
+
 module.exports = function (argv) {
   const json = fs.readFileSync('package.json', 'utf8');
   const pkg = JSON.parse(json);
@@ -49,13 +57,19 @@ module.exports = function (argv) {
       }
     }
   }
+
+  let postversion_script = 'git push --follow-tags && npm publish';
+  if (isScopedPublicPackage(pkg)) {
+    postversion_script += ' --access public';
+  }
+
   if (!has_commits && pkg.homepage) {
     version_script += ' --commits';
   }
 
   addScript(scripts, 'preversion', 'npm test');
   addScript(scripts, 'version', version_script);
-  addScript(scripts, 'postversion', 'git push --follow-tags && npm publish');
+  addScript(scripts, 'postversion', postversion_script);
 
   const indent = detectIndent(json).indent || '  ';
   const out = JSON.stringify(pkg, null, indent);

--- a/test/init-test.js
+++ b/test/init-test.js
@@ -299,4 +299,53 @@ describe('init', () => {
 `
     );
   });
+
+  it('automatically passes `--access public` to scoped public packages', () => {
+    fs.readFileSync
+      .withArgs('package.json')
+      .returns('{"name":"@studio/changes","private":false}');
+
+    const result = init();
+
+    assert.isTrue(result);
+    assert.calledOnceWith(
+      fs.writeFileSync,
+      'package.json',
+      `{
+  "name": "@studio/changes",
+  "private": false,
+  "scripts": {
+    "preversion": "${SCRIPT_PREVERSION}",
+    "version": "${SCRIPT_VERSION}",
+    "postversion": "${SCRIPT_POSTVERSION} --access public"
+  }
+}
+`,
+      'utf8'
+    );
+  });
+
+  it('does not pass `--access` to packages implicitly restricted by a scoped name', () => {
+    fs.readFileSync
+      .withArgs('package.json')
+      .returns('{"name":"@acme-corp/ledger-tool"}');
+
+    const result = init();
+
+    assert.isTrue(result);
+    assert.calledOnceWith(
+      fs.writeFileSync,
+      'package.json',
+      `{
+  "name": "@acme-corp/ledger-tool",
+  "scripts": {
+    "preversion": "${SCRIPT_PREVERSION}",
+    "version": "${SCRIPT_VERSION}",
+    "postversion": "${SCRIPT_POSTVERSION}"
+  }
+}
+`,
+      'utf8'
+    );
+  });
 });


### PR DESCRIPTION
N.B.: This PR might not even be needed, but I noticed that after opening it :sweat_smile: 

---

I use @studio/changes for some projects and always just copied over my npm scripts from the previous project. For the last package I just ran into the following situation:

- The package is scoped (e.g. `@foo/pkg`) __and__ public
- I set up changes using `--init` with default options
- When trying to publish to the npm registry a 402 Payment Required error was returned as npm thought the package should be private (which is the default behavior for scoped packages)
- Setting `private: false` in package.json made no difference
- I noticed my other scoped packages all pass `--access public`
- Adding the flag it to the "broken" package's publish command fixed it

This PR would allow users to pass through a non-default `access` level to `npm publish`.

The one thing I do not understand however: this very package (`@studio/changes`) does not pass `--access public` when publishing, nor does it specify `private` in package.json. How does it work here?

Documentation on `--access` can be found here: https://docs.npmjs.com/cli/v7/commands/npm-publish#description