### PR TITLE
Support for npm workspaces

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -15,6 +15,7 @@ const argv = require('minimist')(process.argv.slice(2), {
     file: 'f',
     tag: 't',
     dir: 'd',
+    workspace: 'w',
     help: 'h'
   }
 });
@@ -30,7 +31,8 @@ Options:
       --footer          Generate a footer with the git author and release date.
   -f, --file [FILENAME] Specify the name of the changelog file. Defaults to CHANGES.md.
   -t, --tag [FORMAT]    Specify a custom git tag format to use. Defaults to "v\${version}".
-  -d, --dir [PATH]      Specify a directory to to filter git log entries.
+  -d, --dir [PATH]      Specify a directory to filter git log entries.
+  -w, --workspace       Convenience flag to set --dir to the current directory name and --tag to "\${dir} v\${version}"
   -h, --help            Display this help message.
 `);
   /* eslint-enable */
@@ -61,6 +63,9 @@ if (argv.commits) {
 }
 if (argv.footer) {
   options.footer = argv.footer;
+}
+if (argv.workspace) {
+  options.workspace = true;
 }
 
 // Write the commit history to the changes file

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -14,6 +14,7 @@ const argv = require('minimist')(process.argv.slice(2), {
     commits: 'c',
     file: 'f',
     tag: 't',
+    dir: 'd',
     help: 'h'
   }
 });
@@ -29,6 +30,7 @@ Options:
       --footer          Generate a footer with the git author and release date.
   -f, --file [FILENAME] Specify the name of the changelog file. Defaults to CHANGES.md.
   -t, --tag [FORMAT]    Specify a custom git tag format to use. Defaults to "v\${version}".
+  -d, --dir [PATH]      Specify a directory to to filter git log entries.
   -h, --help            Display this help message.
 `);
   /* eslint-enable */
@@ -50,6 +52,9 @@ if (argv.file) {
 }
 if (argv.tag) {
   options.tag_format = argv.tag;
+}
+if (argv.dir) {
+  options.dir = argv.dir;
 }
 if (argv.commits) {
   options.commits = argv.commits;

--- a/lib/changelog.js
+++ b/lib/changelog.js
@@ -14,13 +14,16 @@ function parseAuthor(author) {
   return m ? author.substring(0, m.index).trim() : author;
 }
 
-module.exports = function ({ log_range, commits, newline, pkg }) {
+module.exports = function ({ log_range, dir, commits, newline, pkg }) {
   let flags = '--format="» ';
   if (commits) {
     commits = commits.replace(VARIABLE_RE, (match, key) => pkg[key]);
     flags += `[\\\`%h\\\`](${commits}/%H)«  `;
   }
   flags += '%s (%an)%n%n%b" --no-merges';
+  if (dir) {
+    flags += ` -- ${dir}`;
+  }
   let changes;
   try {
     changes = $.execSync(`git log ${log_range} ${flags}`, {

--- a/lib/changes.js
+++ b/lib/changes.js
@@ -89,6 +89,7 @@ exports.write = async function (options = {}) {
 
   let changes = changelog({
     log_range,
+    dir: options.dir,
     commits,
     newline,
     pkg

--- a/lib/changes.js
+++ b/lib/changes.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
 const $ = require('child_process');
 const hostedGitInfo = require('hosted-git-info');
 const changelog = require('./changelog');
@@ -23,8 +24,7 @@ function exists(changes, version) {
   return regexp.test(changes);
 }
 
-function buildTag(options, version, pkg) {
-  const tag_format = options.tag_format || DEFAULT_TAG_FORMAT;
+function buildTag(tag_format, version, pkg) {
   return tag_format.replace(VARIABLE_RE, (match, key) =>
     key === 'version' ? version : pkg[key]
   );
@@ -32,6 +32,13 @@ function buildTag(options, version, pkg) {
 
 // Write the commit history to the changes file
 exports.write = async function (options = {}) {
+  let tag_format = options.tag_format || DEFAULT_TAG_FORMAT;
+  let dir = options.dir;
+  if (options.workspace) {
+    dir = path.basename(process.cwd());
+    tag_format = `${dir}/v\${version}`;
+  }
+
   const changes_file = options.changes_file || DEFAULT_CHANGES_FILE;
   const package_json = fs.readFileSync('package.json', 'utf8');
   const pkg = JSON.parse(package_json);
@@ -60,7 +67,7 @@ exports.write = async function (options = {}) {
   const version_match = previous.match(/^## ([0-9a-z.-]+)$/m);
   let log_range = '';
   if (version_match) {
-    log_range = `${buildTag(options, version_match[1], pkg)}..HEAD`;
+    log_range = `${buildTag(tag_format, version_match[1], pkg)}..HEAD`;
   }
 
   let commits = options.commits;
@@ -89,7 +96,7 @@ exports.write = async function (options = {}) {
 
   let changes = changelog({
     log_range,
-    dir: options.dir,
+    dir,
     commits,
     newline,
     pkg

--- a/test/changes-test.js
+++ b/test/changes-test.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs');
 const $ = require('child_process');
-const { assert, refute, sinon } = require('@sinonjs/referee-sinon');
+const { assert, refute, match, sinon } = require('@sinonjs/referee-sinon');
 const footer = require('../lib/footer');
 const changes = require('..');
 
@@ -157,6 +157,16 @@ describe('changes', () => {
     await changes.write();
 
     assert.calledWithMatch($.execSync, 'git log v0.1.0-beta..HEAD');
+  });
+
+  it('adds `-- my-module` to git log command', async () => {
+    packageJson();
+    missingChanges();
+    setLog('» Inception\n\n\n');
+
+    await changes.write({ dir: 'my-module' });
+
+    assert.calledWith($.execSync, match(/ -- my-module$/));
   });
 
   it('adds body indented on new line', async () => {


### PR DESCRIPTION
This introduces two new options:

- `--dir <dir>` will be passed to `git log -- <dir>` to filter the commit history by this directory.
- `--workspace` is a convenience flag which sets `--dir` to the current directory name and `--tag` to `${dir}/v${version}`.

The purpose of this is to allow generating a change log and tag a module within an npm workspace.

Thoughts?